### PR TITLE
platform: add sound_trigger package

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -77,6 +77,7 @@ PRODUCT_PACKAGES += \
 
 # Audio
 PRODUCT_PACKAGES += \
+    sound_trigger.primary.msm8952 \
     audio.primary.msm8952
 
 # GFX


### PR DESCRIPTION
the sound_trigger has to be defined on each platform so that
the needed libs are built.

Signed-off-by: Alin Jerpelea <alin.jerpelea@sony.com>